### PR TITLE
Skip version check if request fails

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -26,8 +26,13 @@ def cli(ctx, verbose) -> None:
     ctx.ensure_object(dict)
     ctx.obj["VERBOSE"] = verbose
     current_version = Version.parse_version_string(__version__)
-    tags = requests.get("https://api.github.com/repos/git-mastery/app/tags").json()
-    latest_version = Version.parse_version_string(tags[0]["name"])
+    latest_version = (
+        requests.get(
+            "https://github.com/git-mastery/app/releases/latest", allow_redirects=False
+        )
+        .headers["Location"]
+        .rsplit("/", 1)[-1]
+    )
     if current_version.is_behind(latest_version):
         warn(
             click.style(


### PR DESCRIPTION
If getting of the latest version fails (due to Github API rate limiting or other reasons), the following error will be thrown:

```bash
~ gitmastery version
Traceback (most recent call last):
  File "main.py", line 6, in <module>
  File "app\cli.py", line 51, in start
  File "click\core.py", line 1442, in __call__
  File "click\core.py", line 1363, in main
  File "app\cli.py", line 18, in invoke
  File "click\core.py", line 1827, in invoke
  File "click\core.py", line 1226, in invoke
  File "click\core.py", line 794, in invoke
  File "click\decorators.py", line 34, in new_func
  File "app\cli.py", line 30, in cli
KeyError: 0
[PYI-15420:ERROR] Failed to execute script 'main' due to unhandled exception!
```

This PR fixes this error by only validating the version string if the request succeeds