### PR TITLE
Add update command and self-update feature for MacOS

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -1,10 +1,11 @@
 import logging
+import platform
 import sys
 
 import click
 import requests
 
-from app.commands import check, download, progress, setup, verify
+from app.commands import check, download, progress, setup, update, verify
 from app.commands.version import version
 from app.utils.click import ClickColor, CliContextKey, warn
 from app.utils.version import Version
@@ -43,14 +44,20 @@ def cli(ctx, verbose) -> None:
                 fg=ClickColor.BRIGHT_RED,
             )
         )
-        warn("We strongly recommend upgrading your app.")
-        warn(
-            f"Follow the update guide here: {click.style('https://git-mastery.github.io/app/update', bold=True)}"
-        )
+        # Auto-update only supported on macOS
+        # TODO: Add support for other platforms
+        if platform.system().lower() == "darwin":
+            warn("Attempting automatic update...")
+            ctx.invoke(update)
+        else:
+            warn("We strongly recommend upgrading your app.")
+            warn(
+                f"Follow the update guide here: {click.style('https://git-mastery.github.io/app/update', bold=True)}"
+            )
 
 
 def start() -> None:
-    commands = [check, download, progress, setup, verify, version]
+    commands = [check, download, progress, setup, update, verify, version]
     for command in commands:
         cli.add_command(command)
     cli(obj={})

--- a/app/commands/__init__.py
+++ b/app/commands/__init__.py
@@ -1,8 +1,9 @@
-__all__ = ["check", "download", "progress", "setup", "verify", "version"]
+__all__ = ["check", "download", "progress", "setup", "update", "verify", "version"]
 
 from .check import check
 from .download import download
 from .progress.progress import progress
 from .setup_folder import setup
+from .update import update
 from .verify import verify
 from .version import version

--- a/app/commands/update.py
+++ b/app/commands/update.py
@@ -1,0 +1,42 @@
+import logging
+import platform
+import subprocess
+
+import click
+
+from app.utils.click import info, success, warn
+
+logger = logging.getLogger(__name__)
+
+
+def is_macos() -> bool:
+    return platform.system().lower() == "darwin"
+
+
+def run_brew_update() -> bool:
+    """Updates Git-Mastery via Homebrew for macOS."""
+    try:
+        command = ["sh", "-c", "brew update && brew upgrade gitmastery"]
+        info(f"Running: {click.style(' '.join(command), bold=True)}")
+        result = subprocess.run(command)
+        return result.returncode == 0
+    except Exception as e:
+        logger.error(f"Failed to run update command: {e}")
+        return False
+
+
+@click.command()
+def update() -> None:
+    """Update Git-Mastery to the latest version."""
+    if not is_macos():
+        info(
+            "Auto-update is currently only supported on macOS. "
+            "Please follow the update guide: https://git-mastery.github.io/app/update"
+        )
+        return
+
+    info("Detected macOS. Starting update via Homebrew...")
+    if run_brew_update():
+        success("Git-Mastery has been updated successfully!")
+    else:
+        warn("Update command finished with errors. Please check the output above.")


### PR DESCRIPTION
Currently, users have to manually update their app to the latest version if there exists a bug in the app, which can cause inconvenience to users.

This PR aims to introduce a new `update` command that simplifies the updating process for users.

In addition, since we are already checking for the latest version each run, if the current version doesn't match the latest version, we can trigger this update as well.