### PR TITLE
Handle new repo_type local-ignore

### DIFF
--- a/app/commands/download.py
+++ b/app/commands/download.py
@@ -198,7 +198,7 @@ def setup_exercise_folder(
     with open(".gitmastery-exercise.json", "w") as gitmastery_exercise_file:
         gitmastery_exercise_file.write(config.to_json())
 
-    if config.exercise_repo.repo_type == "local":
+    if config.exercise_repo.repo_type == "local" or config.exercise_repo.repo_type == "local-ignore":
         info("Creating custom exercise folder")
         os.makedirs(config.exercise_repo.repo_name, exist_ok=True)
     elif config.exercise_repo.repo_type == "remote":

--- a/app/configs/exercise_config.py
+++ b/app/configs/exercise_config.py
@@ -12,7 +12,7 @@ GITMASTERY_EXERCISE_CONFIG_NAME = ".gitmastery-exercise.json"
 class ExerciseConfig:
     @dataclass
     class ExerciseRepoConfig:
-        repo_type: Literal["local", "remote", "ignore"]
+        repo_type: Literal["local", "remote", "ignore", "local-ignore"]
         repo_name: str
         repo_title: Optional[str]
         create_fork: Optional[bool]


### PR DESCRIPTION
Handle new repo_type `local-ignore` at app level to ensure it behaves identical to `local` during download phase.