### PR TITLE
Update update guide link to point to new site

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -45,7 +45,7 @@ def cli(ctx: click.Context, verbose: bool) -> None:
         )
         warn("We strongly recommend upgrading your app.")
         warn(
-            f"Follow the update guide here: {click.style('https://git-mastery.github.io/app/update', bold=True)}"
+            f"Follow the update guide here: {click.style('https://git-mastery.org/companion-app/index.html#updating-the-git-mastery-app', bold=True)}"
         )
 
 


### PR DESCRIPTION
The message asking the user to update their `gitmastery` app still links to the old site. The new link directs them to the new site instead.