### PR TITLE
Skip repo_smith when exercise doesn't require git init

### DIFF
--- a/app/commands/download.py
+++ b/app/commands/download.py
@@ -255,6 +255,7 @@ def setup_exercise_folder(
 
     info("Executing download setup")
     verbose = get_verbose()
+    # disable local initialization only if init is False, do not disable for remote repositories if set to null
     null_repo = config.exercise_repo.init is False
     with create_repo_smith(verbose, existing_path=".", null_repo=null_repo) as repo_smith:
         namespace.execute_function(


### PR DESCRIPTION
Fixes https://github.com/git-mastery/exercises/issues/219

`repo-smith` function `create_repo_smith` also runs `git init` with initial branch set to `main`. This breaks the expectation of the `init` configuration in `.gitmastery.json`, which causes the issue above.

<img width="580" height="318" alt="image" src="https://github.com/user-attachments/assets/102ecc3c-8e2b-4fa3-8aef-9becffdc2ebd" />

I have verified all call sites where `init` is set to `false` or `null`, and they work as expected. The absence of `rs` object is likely to affect future integration of repo-smith in `download.py` as it no longer has access to `RepoSmith` object during download (this happens in few cases where repo_type is remote + there are still some download steps, eg. mix-messy-docs)