### PR TITLE
Fix help command output incomplete

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -18,7 +18,10 @@ class LoggingGroup(click.Group):
         return super().invoke(ctx)
 
 
-@click.group(cls=LoggingGroup)
+CONTEXT_SETTINGS = {"max_content_width": 120}
+
+
+@click.group(cls=LoggingGroup, context_settings=CONTEXT_SETTINGS)
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
 @click.pass_context
 def cli(ctx: click.Context, verbose: bool) -> None:


### PR DESCRIPTION
Fixes https://github.com/git-mastery/git-mastery/issues/55

Click defaults `content_width` to 80, which causes truncation for long inputs. We can set the `max_content_width` to 120 instead to prevent this issue.

Source: https://click.palletsprojects.com/en/stable/documentation/#click-s-wrapping-behavior


Before: 
<img width="576" height="237" alt="image" src="https://github.com/user-attachments/assets/90775c34-3546-4e1e-b8a3-385ce1ec499f" />


After:
<img width="646" height="237" alt="image" src="https://github.com/user-attachments/assets/751ba673-8362-411b-a817-543f933e3452" />
