### PR TITLE
Fix arch publish release AMD64 URL

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Publish to AUR
         env:
-          RELEASE_AMD64_URL: https://github.com/git-mastery/app/releases/download/${{ github.ref_name }}/gitmastery-${{ env.VERSION }}-arch-amd64
+          RELEASE_AMD64_URL: https://github.com/git-mastery/app/releases/download/${{ needs.prepare.outputs.ref_name }}/gitmastery-${{ env.VERSION }}-arch-amd64
           REF_NAME: ${{ needs.prepare.outputs.ref_name }}
         run: |
           cd aur-pkg


### PR DESCRIPTION
Fixes https://github.com/git-mastery/git-mastery/issues/57

## Problem

The arch-publish GitHub Action publishes an incorrect AMD64 release download URL, which breaks installation on Arch (e.g., via yay gitmastery-bin). Based on workflow logs, releases starting from  ≥7.1.3 are affected.

<img width="1075" height="504" alt="image" src="https://github.com/user-attachments/assets/e2cb139f-d7c4-489d-bd80-58117eaf5c27" />

It is fetching from the following URL:
https://github.com/git-mastery/app/releases/download/main/gitmastery-7.1.4-linux-amd64

Instead, it should be fetching from this URL:
https://github.com/git-mastery/app/releases/download/7.1.4/gitmastery-7.1.4-linux-amd64

## Root Cause

arch-publish is triggered via workflow_run. In this context, ${{ github.ref_name }} resolves to the branch name that triggered the upstream workflow (e.g., main) rather than the release tag.

This causes the action to construct download URLs using main instead of the version tag, even though the actual package version is correctly determined (e.g., logs show pkgver="v7.1.4").

## Fix

Replace ${{ github.ref_name }} with needs.prepare.outputs.ref_name (the tag value)