### PR TITLE
Modify progress reset to redownload base files

### DIFF
--- a/app/commands/progress/reset.py
+++ b/app/commands/progress/reset.py
@@ -68,20 +68,21 @@ def reset() -> None:
         # student has already created the sub-folder needed
         rmtree(exercise_config.path / exercise_config.exercise_repo.repo_name)
 
-    if exercise_config.exercise_repo.repo_type != "ignore":
-        with ExercisesRepo() as repo:
-            formatted_exercise_name = exercise_config.formatted_exercise_name
-            if len(exercise_config.base_files) > 0:
-                info("Re-downloading exercise base files...")
-                for resource, path in exercise_config.base_files.items():
-                    os.makedirs(Path(path).parent, exist_ok=True)
-                    is_binary = Path(path).suffix in [".png", ".jpg", ".jpeg", ".gif"]
-                    repo.download_file(
-                        f"{formatted_exercise_name}/res/{resource}",
-                        exercise_config.path / path,
-                        is_binary,
-                    )
-            
+    with ExercisesRepo() as repo:
+        formatted_exercise_name = exercise_config.formatted_exercise_name
+
+        if len(exercise_config.base_files) > 0:
+            info("Re-downloading exercise base files...")
+            for resource, path in exercise_config.base_files.items():
+                os.makedirs(Path(path).parent, exist_ok=True)
+                is_binary = Path(path).suffix in [".png", ".jpg", ".jpeg", ".gif"]
+                repo.download_file(
+                    f"{formatted_exercise_name}/res/{resource}",
+                    path,
+                    is_binary,
+                )
+
+        if exercise_config.exercise_repo.repo_type != "ignore":
             setup_exercise_folder(repo, download_time, exercise_config)
             info(
                 click.style(


### PR DESCRIPTION
Fixes https://github.com/git-mastery/exercises/issues/240

Currently, we use `base-files` for `answers.txt` file, but we don't reset these base files in `progress reset`. This missing behaviour leads to unexpected results, where students expect `progress reset` to reset their `answers.txt` file, but it is not reset, ie. it is not an entirely clean state as students would expect.

This change adds an additional step in `progress reset` to re-download base files as well to ensure comprehensiveness in `progress reset`, to ensure that the exercise is reset fully.