### PR TITLE
Fix data loss in `rmtree` when deletion fails

### DIFF
--- a/app/utils/cli.py
+++ b/app/utils/cli.py
@@ -35,8 +35,8 @@ def rmtree(folder_name: Union[str, Path]) -> None:
     
     # Create backup
     try:
-        shutil.copytree(folder_path, backup_path, symlinks=True, ignore_dangling_symlinks=True)
-    except Exception as backup_error:
+        shutil.copytree(folder_path, backup_path)
+    except Exception as e:
         error(
             f"Failed to create backup of {folder_name}. Deletion aborted."
         )
@@ -47,10 +47,10 @@ def rmtree(folder_name: Union[str, Path]) -> None:
     
     try:
         shutil.rmtree(folder_path, onerror=force_remove_readonly)
-    except Exception as deletion_error:
+    except Exception as e:
         try:
             shutil.copytree(backup_path, folder_path, dirs_exist_ok=True)
-        except Exception as restoration_error:
+        except Exception as e:
             error(
                 f"Failed to delete {folder_name}. Please make sure it is not accessed by other process. "
                 f"Your data is preserved at: {backup_path}"


### PR DESCRIPTION
Fixes NUS-CS2103-AY2526-S2/forum#82

When `rmtree()` fails (e.g., folder locked by another process), `shutil.rmtree` partially deletes files before raising an exception. This causes permanent data loss - users lose their `progress.json` despite the operation failing. It also applies to other parts in the app that use `rmtree`.

Solution:
Implement backup-and-restore mechanism in `rmtree()`):
1. Create a hidden backup before deletion
2. Attempt deletion
2a. If deletion fails: restore from backup automatically
2b. If restoration also fails: preserve the backup and show the user the path; the user can manually update the path before retrying.