### PR TITLE
Update url link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you wish to contribute to the packaging support, file a PR!
 ### Debian-based distros
 
 1. Install `add-apt-repository`: `sudo apt update && sudo apt-get install software-properties-common`
-2. Add the `gitmastery-apt-repo` repository: `sudo add-apt-repository "deb https://git-mastery.github.io/gitmastery-apt-repo any main"`
+2. Add the `gitmastery-apt-repo` repository: `sudo add-apt-repository "deb https://git-mastery.org/gitmastery-apt-repo any main"`
 3. Install the package: `sudo apt update && sudo apt-get install gitmastery`
 
 ### Arch-based distros

--- a/app/commands/progress/show.py
+++ b/app/commands/progress/show.py
@@ -49,7 +49,7 @@ def show() -> None:
     if config.progress_remote:
         username = get_username()
         dashboard_url = (
-            f"https://git-mastery.github.io/progress-dashboard/#/dashboard/{username}"
+            f"https://git-mastery.org/progress-dashboard/#/dashboard/{username}"
         )
         results.append("")
         results.append(

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ email: woojiahao1234@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   Git-Mastery app installation and usage guide
 baseurl: "/app"
-url: "https://git-mastery.github.io"
+url: "https://git-mastery.org"
 github_username: git-mastery
 
 theme: minima

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -21,7 +21,7 @@ This is the overview of the commands available for Git-Mastery:
 |`gitmastery setup`|Setup Git-Mastery for your local machine.|
 |`gitmastery check git`|Verify that you have setup Git for Git-Mastery|
 |`gitmastery check github`|Verify that you have setup Github and Github CLI for Git-Mastery|
-|`gitmastery download <exercise name>`|Downloads the specified exercise to your local machine. For the list of exercises, refer [here](https://git-mastery.github.io/exercises)|
+|`gitmastery download <exercise name>`|Downloads the specified exercise to your local machine. For the list of exercises, refer [here](https://git-mastery.org/exercises)|
 |`gitmastery verify`|Verify your exercise attempt. Saves the progress made.|
 |`gitmastery version`|Get the current version of the Git-Mastery app on your machine.|
 |`gitmastery progress sync on`|Enable remote progress tracking.|

--- a/docs/linux.markdown
+++ b/docs/linux.markdown
@@ -63,10 +63,10 @@ Ensure you are running `libc` version 2.38 or newer.
 Then install the following:
 
 ```bash
-echo "deb [trusted=yes] https://git-mastery.github.io/gitmastery-apt-repo any main" | \
+echo "deb [trusted=yes] https://git-mastery.org/gitmastery-apt-repo any main" | \
   sudo tee /etc/apt/sources.list.d/gitmastery.list > /dev/null
 sudo apt install software-properties-common
-sudo add-apt-repository "deb https://git-mastery.github.io/gitmastery-apt-repo any main"
+sudo add-apt-repository "deb https://git-mastery.org/gitmastery-apt-repo any main"
 sudo apt update
 sudo apt-get install gitmastery
 ```

--- a/docs/windows-wsl.markdown
+++ b/docs/windows-wsl.markdown
@@ -109,10 +109,10 @@ Ensure you are running `libc` version 2.38 or newer.
 Then install the following:
 
 ```bash
-echo "deb [trusted=yes] https://git-mastery.github.io/gitmastery-apt-repo any main" | \
+echo "deb [trusted=yes] https://git-mastery.org/gitmastery-apt-repo any main" | \
   sudo tee /etc/apt/sources.list.d/gitmastery.list > /dev/null
 sudo apt install software-properties-common
-sudo add-apt-repository "deb https://git-mastery.github.io/gitmastery-apt-repo any main"
+sudo add-apt-repository "deb https://git-mastery.org/gitmastery-apt-repo any main"
 sudo apt update
 sudo apt-get install gitmastery
 ```


### PR DESCRIPTION
Some of the links are still showing `https://git-mastery.github.io`; we should change them to `https://git-mastery.org` for consistency and to avoid unnecessary redirects.

Closes #47 