### PR TITLE
Add optimisations to E2E CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
 
   test-e2e:
     name: E2E Tests (${{ matrix.os }})
-    if: github.event_name != 'pull_request_target'
+    if: github.event_name != 'pull_request_target' && github.repository == 'git-mastery/app'
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
## Summary
- Add an early `GH_PAT` validation step in both E2E jobs so CI fails immediately with a clear error when the secret is missing.
- Restrict test-e2e to run only on the upstream repo (git-mastery/app).

## Why
- Avoid wasting CI time when required secret is not configured.
- Prevent fork/non-upstream runs from triggering the E2E workflow on every push to main.