### PR TITLE
Split test workflow into PR and main branch push

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   test-e2e-pr:
     name: E2E Tests (${{ matrix.os }})
+    if: github.repository == 'git-mastery/app'
     # Require manual approval before secrets are exposed to untrusted PR code
     environment: e2e-test
     runs-on: ${{ matrix.os }}
@@ -21,6 +22,16 @@ jobs:
         python-version: ["3.13"]
 
     steps:
+      - name: Validate GH_PAT secret
+        shell: bash
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -z "$GH_PAT" ]; then
+            echo "GH_PAT secret is required to run E2E tests."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   test-e2e:


### PR DESCRIPTION
Separates the single test.yml workflow (which used two jobs with if: guards on github.event_name) into two dedicated files:

1. test-pr.yml: runs on pull_request_target with the e2e-test environment gate to protect secrets from untrusted PR code
2. test.yml: runs on push to main and workflow_dispatch

This makes the intent of each workflow clearer and removes the need for runtime if: conditions to differentiate between event types.