### PR TITLE
Add winget-publish action in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -401,6 +401,9 @@ jobs:
 
     runs-on: windows-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Submit to WinGet
         uses: vedantmgoyal9/winget-releaser@v2


### PR DESCRIPTION
Fixes https://github.com/git-mastery/git-mastery/issues/67

Adds a winget-publish job that runs after the windows build job and submits each release to the Windows Package Manager (WinGet) community repository via `vedantmgoyal9/winget-releaser@v2`.
