### PR TITLE
Fix winget-releaser version number

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -411,7 +411,7 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: GitMastery.GitMastery
-          version: ${{ needs.prepare.outputs.version_number }}
+          version: ${{ needs.prepare.outputs.ref_name }}
           token: ${{ secrets.ORG_PAT }}
           installers-regex: '\.exe$'
 


### PR DESCRIPTION
## Summary

* Currently failing winget releaser action due to wrong version number, should be v7.8.0 instead of 7.7.0
* https://github.com/git-mastery/app/actions/runs/23382810589/job/68024961437