### PR TITLE
Fix winget releaser action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -411,7 +411,8 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: GitMastery.GitMastery
-          version: ${{ needs.prepare.outputs.ref_name }}
+          version: ${{ needs.prepare.outputs.version_number }}
+          release-tag: ${{ needs.prepare.outputs.ref_name }}
           token: ${{ secrets.ORG_PAT }}
           installers-regex: '\.exe$'
 


### PR DESCRIPTION
## Summary

* v7.8.1 is still failing for winget releaser action
* It seems to be fetching from https://api.github.com/repos/git-mastery/app/releases/tags/main instead
* Appears to be because we didn't specify `release-tag`