### PR TITLE
Add support for gitmastery alias commands

### DIFF
--- a/app/aliases.py
+++ b/app/aliases.py
@@ -1,0 +1,16 @@
+COMMAND_ALIASES: dict[str, list[str]] = {
+    "download": ["d"],
+    "verify": ["v"],
+    "setup": ["s"],
+    "check": ["c"],
+    "progress": ["p"],
+    "version": ["ver"],
+}
+
+
+def resolve_alias(name: str) -> str:
+    """Resolve an alias to its full command name, or return the name unchanged."""
+    for command, aliases in COMMAND_ALIASES.items():
+        if name in aliases:
+            return command
+    return name

--- a/app/cli.py
+++ b/app/cli.py
@@ -3,7 +3,9 @@ import sys
 
 import click
 import requests
+from click_aliases import ClickAliasedGroup
 
+from app.aliases import COMMAND_ALIASES
 from app.commands import check, download, progress, setup, verify
 from app.commands.repl import repl
 from app.commands.version import version
@@ -12,7 +14,7 @@ from app.utils.version import Version
 from app.version import __version__
 
 
-class LoggingGroup(click.Group):
+class LoggingGroup(ClickAliasedGroup):
     def invoke(self, ctx: click.Context) -> None:
         logger = logging.getLogger(__name__)
         logger.info("Running command %s with arguments %s", ctx.command_path, sys.argv)
@@ -63,5 +65,8 @@ def cli(ctx: click.Context, verbose: bool) -> None:
 def start() -> None:
     commands = [check, download, progress, setup, verify, version]
     for command in commands:
-        cli.add_command(command)
+        if command.name and command.name in COMMAND_ALIASES:
+            cli.add_command(command, aliases=COMMAND_ALIASES[command.name])
+        else:
+            cli.add_command(command)
     cli(obj={})

--- a/app/commands/repl.py
+++ b/app/commands/repl.py
@@ -7,6 +7,7 @@ from typing import List
 
 import click
 
+from app.aliases import COMMAND_ALIASES, resolve_alias
 from app.commands.check import check
 from app.commands.download import download
 from app.commands.progress.progress import progress
@@ -91,7 +92,7 @@ Shell commands are also supported.
         if command_name.lower() == "gitmastery":
             if not args:
                 return
-            gitmastery_command = args[0]
+            gitmastery_command = resolve_alias(args[0])
             if gitmastery_command in ("exit", "quit"):
                 return self.do_exit("")  # type: ignore[return-value]
             elif gitmastery_command == "help":
@@ -188,7 +189,10 @@ Shell commands are also supported.
         )
         for name, command in GITMASTERY_COMMANDS.items():
             help_text = (command.help or "No description available.").strip()
-            click.echo(f"  {click.style(f'/{name:<20}', bold=True)} {help_text}")
+            aliases = COMMAND_ALIASES.get(name, [])
+            alias_str = f" (/{', /'.join(aliases)})" if aliases else ""
+            label = f"/{name}{alias_str}"
+            click.echo(f"  {click.style(f'{label:<25}', bold=True)} {help_text}")
 
         click.echo(
             click.style("\nBuilt-in Commands:", bold=True, fg=ClickColor.BRIGHT_CYAN)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
     "click==8.3.1",
+    "click-aliases==1.0.5",
     "difflib-parser==2.1.1",
     "git-autograder==6.6.0",
     "gitpython==3.1.46",

--- a/uv.lock
+++ b/uv.lock
@@ -90,6 +90,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click-aliases"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/d8/adbaeadc13c9686b9bda8b4c50e5a3983f504faae2ffbea5165d5beb1cdb/click_aliases-1.0.5.tar.gz", hash = "sha256:e37d4cabbaad68e1c48ec0f063a59dfa15f0e7450ec901bd1ce4f4b954bc881d", size = 3105, upload-time = "2024-10-17T15:44:19.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/1a/d5e29a6f896293e32ab3e63201df5d396599e57a726575adaafbcd9d70a6/click_aliases-1.0.5-py3-none-any.whl", hash = "sha256:cbb83a348acc00809fe18b6da13a7f6307bc71b3c5f69cc730e012dfb4bbfdc3", size = 3524, upload-time = "2024-10-17T15:44:17.389Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -141,6 +153,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },
+    { name = "click-aliases" },
     { name = "difflib-parser" },
     { name = "git-autograder" },
     { name = "gitpython" },
@@ -174,6 +187,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = "==8.3.1" },
+    { name = "click-aliases", specifier = "==1.0.5" },
     { name = "difflib-parser", specifier = "==2.1.1" },
     { name = "git-autograder", specifier = "==6.6.0" },
     { name = "gitpython", specifier = "==3.1.46" },


### PR DESCRIPTION
Fixes #73 

### Summary
- Add short aliases for CLI commands (e.g. d for download, v for verify)
- Implemented by using `ClickAliasedGroup` from `click_aliases` (https://pypi.org/project/click-aliases/)
- Aliases are shown in parentheses (e.g. `download (d)`) 

### Note
Encountered a "No [mypy] section in config file" warning when trying to commit