### PR TITLE
feat: add global exception handling

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -8,7 +8,7 @@ from app.aliases import COMMAND_ALIASES
 from app.commands import check, download, progress, setup, verify
 from app.commands.repl import repl
 from app.commands.version import version
-from app.utils.click import ClickColor, CliContextKey, warn
+from app.utils.click import ClickColor, CliContextKey, handle_unexpected_error, warn
 from app.utils.version import Version, fetch_latest_release_version
 from app.version import __version__
 
@@ -31,7 +31,6 @@ CONTEXT_SETTINGS = {"max_content_width": 120}
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
 @click.pass_context
 def cli(ctx: click.Context, verbose: bool) -> None:
-    """Git-Mastery app"""
     ctx.ensure_object(dict)
 
     ctx.obj[CliContextKey.VERBOSE] = verbose
@@ -67,4 +66,8 @@ def start() -> None:
             cli.add_command(command, aliases=COMMAND_ALIASES[command.name])
         else:
             cli.add_command(command)
-    cli(obj={})
+    try:
+        cli(obj={})
+    except Exception as e:
+        handle_unexpected_error(e)
+        sys.exit(1)

--- a/app/commands/repl.py
+++ b/app/commands/repl.py
@@ -14,7 +14,7 @@ from app.commands.progress.progress import progress
 from app.commands.setup_folder import setup
 from app.commands.verify import verify
 from app.commands.version import version
-from app.utils.click import CliContextKey, ClickColor
+from app.utils.click import CliContextKey, ClickColor, handle_unexpected_error
 from app.utils.version import Version
 from app.version import __version__
 
@@ -128,7 +128,7 @@ Shell commands are also supported.
         except SystemExit:
             pass
         except Exception as e:
-            click.echo(click.style(f"Error: {e}", fg=ClickColor.BRIGHT_RED))
+            handle_unexpected_error(e)
         finally:
             try:
                 os.chdir(original_cwd)

--- a/app/utils/click.py
+++ b/app/utils/click.py
@@ -6,7 +6,13 @@ from typing import Any, NoReturn, Optional
 import click
 
 from app.configs.exercise_config import ExerciseConfig
-from app.configs.gitmastery_config import GitMasteryConfig
+from app.configs.gitmastery_config import (
+    GITMASTERY_CONFIG_NAME,
+    GITMASTERY_LOG_NAME,
+    METADATA_FOLDER_NAME,
+    GitMasteryConfig,
+)
+from app.configs.utils import find_root
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +49,16 @@ def error(message: str) -> NoReturn:
         f"{click.style(' ERROR ', fg=ClickColor.BLACK, bg=ClickColor.BRIGHT_RED, bold=True)} {message}"
     )
     sys.exit(1)
+
+
+def handle_unexpected_error(exception: Exception) -> None:
+    logger.exception("Unexpected error: %s", exception)
+    message = f"An unexpected error occurred: {type(exception).__name__}: {exception}"
+    if find_root(GITMASTERY_CONFIG_NAME, folder=METADATA_FOLDER_NAME) is not None:
+        message += f" See {METADATA_FOLDER_NAME}/{GITMASTERY_LOG_NAME} for details."
+    click.echo(
+        f"{click.style(' ERROR ', fg=ClickColor.BLACK, bg=ClickColor.BRIGHT_RED, bold=True)} {message}"
+    )
 
 
 def info(message: str) -> None:


### PR DESCRIPTION
## Overview

Hide unexpected exception stack traces from users.

* Catch unexpected exceptions at CLI startup and in the REPL so users see a short ERROR line instead of a Python traceback
* Log the full stack to `.gitmastery/gitmastery.log` when a project root exists
* All other expected errors remain unchanged


### Test Plan
- [ ] Terminal shows one ERROR line (no traceback), exit code 1, on unexpected error
- [ ] REPL should not exit the session on unexpecteed error
- [ ] Confirm `.gitmastery/gitmastery.log` has the traceback if inside gitmastery folder


No e2e test is needed, not part of critical path to test.